### PR TITLE
[devops] Setup action for syncing deploy new relic - detran-microservices (Minor)

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -94,3 +94,14 @@ runs:
         aws ecr get-login-password --region sa-east-1 | helm registry login --username AWS --password-stdin 071032557399.dkr.ecr.sa-east-1.amazonaws.com
         helm dependency build ./.github/helm-deploy/$ENVIRONMENT
         helm upgrade --atomic --timeout ${{ inputs.helm-timeout }} --debug --install $APPLICATION_NAME ./.github/helm-deploy/$ENVIRONMENT -f ./.github/helm-deploy/$ENVIRONMENT/${{ inputs.values-file }} -n $CLUSTER_NAMESPACE
+
+    ## Config new relic deployment marker
+    - name: New Relic Deployment Marker
+      uses: newrelic/deployment-marker-action@v2.3.0
+      with:
+        apiKey: ${{ inputs.apiKey }}
+        guid: ${{ inputs.new_relic_deployment_entity_guid }}
+        version: "${{ inputs.image-tag }}"
+        user: "${{ github.actor }}"
+        commit: "${{ github.sha }}"
+        description: "Automated Release via Github Actions"


### PR DESCRIPTION
Esse PR tem como objetivo adicionar um novo step na action usada pelo serviço `detran-microservices`. Com isso, habilitamos o `detran-microservices` a enviar informações de deploy para o New Relic, a partir do momento que os parâmetros corretos forem encaminhados.

Observação: seria interessante integrar a branch `detran-microservices` com a branch `main` no futuro, se possível.